### PR TITLE
Handling Invalid Expression Error

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -13,6 +13,9 @@ const Calculator = () => {
 	const [result, setResult] = useState("");
 
 	const handleEvaluation = (value) => {
+		if (input === '') {
+			setResult('')
+		}
 		setInput((prevInput) => prevInput + value);
 	};
 	const handleClear = () => {
@@ -27,7 +30,8 @@ const Calculator = () => {
 		try {
 			setResult(eval(input).toString());
 		} catch (error) {
-			setResult(error);
+			setResult('Invalid Expression');
+			setInput('')
 		}
 	};
 	return (


### PR DESCRIPTION
When user enters an invalid expression for example 5***3, so control goes inside catch but inside catch, the `setResult(error)` sets the error object to state which gives error.

User is not concerned with error so just showing 'Invalid Expression' will work.